### PR TITLE
replace INSTANTIATE_TEST_CASE_P with INSTANTIATE_TEST_SUITE_P.

### DIFF
--- a/tests/test3.cpp
+++ b/tests/test3.cpp
@@ -56,7 +56,7 @@ const ValueResult valuesAdd[] =
     {1, 2, 3},
 };
 
-INSTANTIATE_TEST_CASE_P(TestTestParamInstance,
+INSTANTIATE_TEST_SUITE_P(TestTestParamInstance,
                         TestTestParamAdd,
                         ::testing::ValuesIn(valuesAdd));
 
@@ -67,7 +67,7 @@ const ValueResult valuesSubtract[] =
     {3, 2, 1},
 };
 
-INSTANTIATE_TEST_CASE_P(TestTestParamInstance,
+INSTANTIATE_TEST_SUITE_P(TestTestParamInstance,
                         TestTestParamSubtract,
                         ::testing::ValuesIn(valuesSubtract));
 
@@ -78,7 +78,7 @@ const ValueResult valuesDivide[] =
     {3, 2, 1},
 };
 
-INSTANTIATE_TEST_CASE_P(TestTestParamInstance,
+INSTANTIATE_TEST_SUITE_P(TestTestParamInstance,
                         TestTestParamDivide,
                         ::testing::ValuesIn(valuesDivide));
 

--- a/tests/test4.cpp
+++ b/tests/test4.cpp
@@ -39,7 +39,7 @@ void PrintTo(const ValueResult& value, std::ostream* os)
 }
 
 
-INSTANTIATE_TEST_CASE_P(TestTestParamInstance,
+INSTANTIATE_TEST_SUITE_P(TestTestParamInstance,
                         TestParamName,
                         ::testing::ValuesIn(valuesAdd),
                         ::testing::PrintToStringParamName()

--- a/tests/test5.cpp
+++ b/tests/test5.cpp
@@ -52,7 +52,7 @@ void PrintTo(const Parameters& params, std::ostream* os)
 }
 
 
-INSTANTIATE_TEST_CASE_P(TestTestParamInstance,
+INSTANTIATE_TEST_SUITE_P(TestTestParamInstance,
                         TestParamNameCombine,
                         ::testing::Combine(
                             ::testing::ValuesIn(desc),


### PR DESCRIPTION
replace INSTANTIATE_TEST_CASE_P with INSTANTIATE_TEST_SUITE_P.

https://ethz-adrl.github.io/ct/ct_core/doc/html/md__home_adrl_code_src_control-toolbox_ct_core_build_test_googletest-src_googletest_docs_advanced.html

> For 1.8.1 and previous releases the keyword is INSTANTIATE_TEST_CASE_P. which has been deprecated in favor of INSTANTIATE_TEST_SUITE_P.
